### PR TITLE
index.Rmd typo fix (needs rendering)

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Centre of Water Resources Studies (CWRS) Data Hub"
+title: "Centre for Water Resources Studies (CWRS) Data Hub"
 site: distill::distill_website
 ---
 
@@ -32,7 +32,7 @@ library(bslib)
 library(lubridate)
 ```
 
-This website serves as a data hub that displays projects conducted by Centre of Water Resources Studies (CWRS), Dalhousie University:
+This website serves as a data hub that displays projects conducted by Centre for Water Resources Studies (CWRS), Dalhousie University:
 
 
 [Nova Scotia wastewater COVID-19 surveillance](https://cwrs-dal.github.io/CWRS-DAL.io/c19ww.html)


### PR DESCRIPTION
Caught another typo on the main page. Render "index.Rmd" to fix.